### PR TITLE
Add quotes to reserved keyword as field name

### DIFF
--- a/dlf/ext_tables.sql
+++ b/dlf/ext_tables.sql
@@ -88,7 +88,7 @@ CREATE TABLE tx_dlf_metadata (
     default_value text NOT NULL,
     wrap text NOT NULL,
     tokenized tinyint(4) DEFAULT '0' NOT NULL,
-    stored tinyint(4) DEFAULT '0' NOT NULL,
+    `stored` tinyint(4) DEFAULT '0' NOT NULL,
     indexed tinyint(4) DEFAULT '0' NOT NULL,
     boost float(4,2) DEFAULT '1.00' NOT NULL,
     is_sortable tinyint(4) DEFAULT '0' NOT NULL,


### PR DESCRIPTION
The keyword `stored` was added to the list of reserved words as of MySQL 5.7.6 and the `CREATE`-Statement throws a syntax error from this MySQL version onward

https://dev.mysql.com/doc/refman/5.7/en/keywords.html

http://stackoverflow.com/questions/23446377/syntax-error-due-to-using-a-reserved-word-as-a-table-or-column-name-in-mysql#23446378